### PR TITLE
Add the `dish` and `sink` LWRPs.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,25 @@
+---
+driver:
+  name: <%= ENV['TRAVIS'] ? 'localhost' : 'vagrant' %>
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-12.04
+
+suites:
+  - name: default
+    run_list:
+      - recipe[test_dishes::integration_test_recipe]
+    attributes:
+      dishes:
+        dish:
+          first_dish:
+            recipe: test_dishes::first_dish_recipe
+            wash_recipe: test_dishes::first_wash_recipe
+            sink: default
+          second_dish:
+            recipe: test_dishes::second_dish_recipe
+            wash_recipe: test_dishes::second_wash_recipe
+            sink: default

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--color --format documentation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
 AllCops:
   Exclude:
-    - metadata.rb
+    - ./**/metadata.rb
     - vendor/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm: 2.2
 cache: bundler
 
-sudo: false
+sudo: true
 
 addons:
   apt:
@@ -9,12 +9,3 @@ addons:
     - chef-current-precise
     packages:
     - chefdk
-
-before_script:
-- eval "$(/opt/chefdk/bin/chef shell-init bash)"
-
-script:
-- "/opt/chefdk/embedded/bin/chef --version"
-- "/opt/chefdk/embedded/bin/rubocop --version"
-- "/opt/chefdk/embedded/bin/foodcritic --version"
-- "/opt/chefdk/embedded/bin/rake"

--- a/Berksfile
+++ b/Berksfile
@@ -3,4 +3,5 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :integration do
+  cookbook 'test_dishes', path: 'test/fixtures/cookbooks/test_dishes'
 end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,13 @@
+if defined?(ChefSpec)
+  def use_dishes_dish(name)
+    ChefSpec::Matchers::ResourceMatcher.new('dishes_dish', 'use', name)
+  end
+
+  def toss_dishes_dish(name)
+    ChefSpec::Matchers::ResourceMatcher.new('dishes_dish', 'toss', name)
+  end
+
+  def wash_dishes_sink(name)
+    ChefSpec::Matchers::ResourceMatcher.new('dishes_sink', 'wash', name)
+  end
+end

--- a/providers/dish.rb
+++ b/providers/dish.rb
@@ -1,0 +1,18 @@
+action :use do
+  prior_dish = (node.set['dishes']['dish'] ||= {})[new_resource.identity]
+  new_dish = {
+    'recipe' => new_resource.recipe,
+    'wash_recipe' => new_resource.wash_recipe,
+    'sink' => new_resource.sink
+  }
+
+  node.set['dishes']['dish'][new_resource.identity] = new_dish
+
+  new_resource.updated_by_last_action(prior_dish != new_dish)
+end
+
+action :toss do
+  was_present = (node.set['dishes']['dish'] ||= {}).key?(new_resource.identity)
+  node.set['dishes']['dish'].delete(new_resource.identity)
+  new_resource.updated_by_last_action(was_present)
+end

--- a/providers/sink.rb
+++ b/providers/sink.rb
@@ -1,0 +1,15 @@
+action :wash do
+  dishes = (node.set['dishes']['dish'] ||= {})
+
+  washable_dishes = dishes.values.select do |dish|
+    new_resource.sink == dish['sink'] &&
+    !node.recipe?(dish['recipe']) &&
+    !node.recipe?(dish['wash_recipe'])
+  end
+
+  washable_dishes.each do |dish|
+    run_context.include_recipe dish['wash_recipe']
+  end
+
+  new_resource.updated_by_last_action(washable_dishes.any?)
+end

--- a/resources/dish.rb
+++ b/resources/dish.rb
@@ -1,0 +1,6 @@
+actions :use, :toss
+default_action :use
+
+attribute :recipe, kind_of: String, name_attribute: true
+attribute :wash_recipe, kind_of: String, required: true
+attribute :sink, kind_of: String, default: 'default'

--- a/resources/sink.rb
+++ b/resources/sink.rb
@@ -1,0 +1,4 @@
+actions :wash
+default_action :wash
+
+attribute :sink, kind_of: String, name_attribute: true

--- a/spec/dish_spec.rb
+++ b/spec/dish_spec.rb
@@ -1,0 +1,166 @@
+require 'spec_helper'
+
+describe 'dishes::dish' do
+  let(:server_runner) { ChefSpec::ServerRunner.new step_into: 'dishes_dish' }
+  let(:name) { 'the-name' }
+  let(:calling_recipe) { 'test_dishes::dish_spec_recipe' }
+
+  let(:action) { :use }
+  let(:recipe) { 'dish_cookbook::dish_recipe' }
+  let(:wash_recipe) { 'wash_cookbook::wash_recipe' }
+  let(:sink) { 'the-sink' }
+
+  let(:chef_run) do
+    attrs = {}
+    attrs['name'] = name if name
+    attrs['action'] = action if action
+    attrs['recipe'] = recipe if recipe
+    attrs['wash_recipe'] = wash_recipe if wash_recipe
+    attrs['sink'] = sink if sink
+
+    server_runner.node.set['test_dishes']['dish_spec_recipe'] = attrs
+    server_runner.converge(calling_recipe)
+  end
+
+  # Since we deal with state between runs, here is a nominally earlier run
+  let(:prior_action) { action }
+  let(:prior_recipe) { recipe }
+  let(:prior_wash_recipe) { wash_recipe }
+  let(:prior_sink) { sink }
+
+  let(:prior_chef_run) do
+    attrs = {}
+    attrs['name'] = name if name
+    attrs['action'] = prior_action if prior_action
+    attrs['recipe'] = prior_recipe if prior_recipe
+    attrs['wash_recipe'] = prior_wash_recipe if prior_wash_recipe
+    attrs['sink'] = prior_sink if prior_sink
+
+    server_runner.node.set['test_dishes']['dish_spec_recipe'] = attrs
+    server_runner.converge(calling_recipe)
+  end
+
+  let(:resource) { chef_run.find_resource(:dishes_dish, name) }
+
+  it 'runs' do
+    chef_run
+  end
+
+  shared_examples_for 'a changed resource' do
+    it 'is updated by the last action' do
+      expect(resource).to be_updated_by_last_action
+    end
+  end
+
+  shared_examples_for 'an unchanged resource' do
+    it 'is not updated by the last action' do
+      expect(resource).to_not be_updated_by_last_action
+    end
+  end
+
+  # Throughout we cheat and assume there is only one dish in the recipe.
+
+  describe 'without a recipe attribute' do
+    let(:recipe) { nil }
+
+    it 'assumes the name' do
+      expect(resource.recipe).to eq(name)
+    end
+  end
+
+  describe 'without a wash_recipe attribute' do
+    let(:wash_recipe) { nil }
+
+    it 'fails validation' do
+      expect { chef_run }.to raise_error(Chef::Exceptions::ValidationFailed)
+    end
+  end
+
+  describe 'without a sink attribute' do
+    let(:sink) { nil }
+
+    it 'assumes "default"' do
+      expect(resource.sink).to eq('default')
+    end
+  end
+
+  describe 'with action :use' do
+    let(:action) { :use }
+
+    shared_examples_for 'a used dish' do
+      it 'records itself in node attributes' do
+        expect(chef_run.node['dishes']['dish'][name.to_s]).to eq(
+          'recipe' => recipe,
+          'wash_recipe' => wash_recipe,
+          'sink' => sink
+        )
+      end
+
+      it 'leaves no other state' do
+        expect(chef_run.node['dishes']['dish'].size).to eq(1)
+      end
+    end
+
+    describe 'on first run' do
+      it_should_behave_like 'a used dish'
+      it_should_behave_like 'a changed resource'
+    end
+
+    describe 'on second run without changes' do
+      before do
+        prior_chef_run
+      end
+
+      it_should_behave_like 'a used dish'
+      it_should_behave_like 'an unchanged resource'
+    end
+
+    %w(recipe wash_recipe sink).each do |attribute|
+      describe "on second run after changing #{attribute}" do
+        let(:"prior_#{attribute}") { "different-#{attribute}" }
+
+        before do
+          prior_chef_run
+        end
+
+        it_should_behave_like 'a used dish'
+        it_should_behave_like 'a changed resource'
+      end
+    end
+  end
+
+  describe 'with action :toss' do
+    let(:action) { :toss }
+
+    shared_examples_for 'a tossed dish' do
+      it 'removes itself from node attributes' do
+        expect(chef_run.node['dishes']['dish']).to_not have_key(name.to_s)
+      end
+    end
+
+    describe 'on first run' do
+      it_should_behave_like 'a tossed dish'
+      it_should_behave_like 'an unchanged resource'
+    end
+
+    describe 'on second run without changes' do
+      before do
+        prior_chef_run
+      end
+
+      it_should_behave_like 'a tossed dish'
+      it_should_behave_like 'an unchanged resource'
+    end
+
+    describe 'on second run after using' do
+      let(:prior_action) { :use }
+
+      before do
+        prior_chef_run
+      end
+
+      it_should_behave_like 'a tossed dish'
+      it_should_behave_like 'a changed resource'
+    end
+  end
+end

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'dishes custom matchers' do
+  let(:name) { 'the-name' }
+  let(:recipe) { 'dish_cookbook::dish_recipe' }
+  let(:wash_recipe) { 'wash_cookbook::wash_recipe' }
+  let(:sink) { 'the-sink' }
+
+  let(:dish_chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      attrs = node.set['test_dishes']['dish_spec_recipe']
+      attrs['name'] = name
+      attrs['action'] = action
+      attrs['recipe'] = recipe
+      attrs['wash_recipe'] = wash_recipe
+      attrs['sink'] = sink
+    end.converge('test_dishes::dish_spec_recipe')
+  end
+
+  let(:sink_chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      attrs = node.set['test_dishes']['sink_spec_recipe']
+      attrs['name'] = name
+      attrs['action'] = action
+      attrs['sink'] = sink
+    end.converge('test_dishes::sink_spec_recipe')
+  end
+
+  describe 'use_dishes_dish' do
+    let(:action) { :use }
+
+    it 'can match' do
+      expect(dish_chef_run).to use_dishes_dish(name).with(
+        recipe: recipe,
+        wash_recipe: wash_recipe,
+        sink: sink
+      )
+    end
+  end
+
+  describe 'toss_dishes_dish' do
+    let(:action) { :toss }
+
+    it 'can match' do
+      expect(dish_chef_run).to toss_dishes_dish(name).with(
+        recipe: recipe,
+        wash_recipe: wash_recipe,
+        sink: sink
+      )
+    end
+  end
+
+  describe 'wash_dishes_sink' do
+    let(:action) { :wash }
+
+    it 'can match' do
+      expect(sink_chef_run).to wash_dishes_sink(name).with(
+        sink: sink
+      )
+    end
+  end
+end

--- a/spec/sink_spec.rb
+++ b/spec/sink_spec.rb
@@ -1,0 +1,148 @@
+require 'spec_helper'
+
+describe 'dishes::sink' do
+  # let(:server_runner) { ChefSpec::ServerRunner.new step_into: 'dishes_sink' }
+  let(:name) { 'the-name' }
+  let(:calling_recipe) { 'test_dishes::sink_spec_recipe' }
+  let(:action) { :wash }
+  let(:sink) { 'the-sink' }
+  let(:different_sink) { 'different-sink' }
+
+  let(:first_dish_recipe) { 'test_dishes::first_dish_recipe' }
+  let(:first_wash_recipe) { 'test_dishes::first_wash_recipe' }
+  let(:first_dish_sink) { sink }
+
+  let(:second_dish_recipe) { 'test_dishes::second_dish_recipe' }
+  let(:second_wash_recipe) { 'test_dishes::second_wash_recipe' }
+  let(:second_dish_sink) { sink }
+
+  let(:dishes) do
+    {
+      'first-dish' => {
+        'recipe' => first_dish_recipe,
+        'wash_recipe' => first_wash_recipe,
+        'sink' => first_dish_sink
+      },
+      'second-dish' => {
+        'recipe' => second_dish_recipe,
+        'wash_recipe' => second_wash_recipe,
+        'sink' => second_dish_sink
+      }
+    }
+  end
+
+  let(:explicit_run_list) { [calling_recipe] }
+
+  let(:chef_run) do
+    ChefSpec::ServerRunner.new step_into: 'dishes_sink' do |node|
+      attrs = {}
+      attrs['name'] = name if name
+      attrs['action'] = action if action
+      attrs['sink'] = sink if sink
+
+      node.set['test_dishes']['sink_spec_recipe'] = attrs
+
+      node.set['dishes']['dish'] = dishes if dishes
+    end.converge(*explicit_run_list)
+  end
+
+  it 'runs' do
+    chef_run
+  end
+
+  let(:resource) { chef_run.find_resource(:dishes_sink, name) }
+
+  describe 'without a sink attribute' do
+    let(:sink) { nil }
+
+    it 'assumes the name' do
+      expect(resource.sink).to eq(name)
+    end
+  end
+
+  describe 'with action :wash' do
+    let(:action) { :wash }
+    let(:wash_recipes) { [] }
+
+    shared_examples_for 'an empty sink' do
+      it 'includes nothing' do
+        expect(chef_run.node.recipes).to eq(explicit_run_list)
+      end
+
+      it 'is not updated by the last action' do
+        expect(resource).to_not be_updated_by_last_action
+      end
+    end
+
+    shared_examples_for 'a full sink' do
+      it 'includes the wash recipes of dirty dishes' do
+        wash_recipes.each do |wash_recipe|
+          expect(chef_run).to include_recipe(wash_recipe)
+        end
+      end
+
+      it 'is updated by the last action' do
+        expect(resource).to be_updated_by_last_action
+      end
+    end
+
+    describe 'with no dishes' do
+      let(:dishes) { nil }
+      it_should_behave_like 'an empty sink'
+    end
+
+    describe 'with dirty dishes' do
+      let(:wash_recipes) { [first_wash_recipe, second_wash_recipe] }
+      it_should_behave_like 'a full sink'
+    end
+
+    describe 'with dirty dishes in a different sink' do
+      let(:first_dish_sink) { different_sink }
+      let(:second_dish_sink) { different_sink }
+      it_should_behave_like 'an empty sink'
+    end
+
+    describe 'with dirty dishes in many sinks' do
+      let(:second_dish_sink) { different_sink }
+      let(:wash_recipes) { [first_wash_recipe] }
+      it_should_behave_like 'a full sink'
+    end
+
+    describe 'with dishes that have already been cleaned up' do
+      let(:explicit_run_list) do
+        [calling_recipe, first_wash_recipe, second_wash_recipe]
+      end
+
+      it_should_behave_like 'an empty sink'
+    end
+
+    describe 'with a mix of dishes that have been cleaned up and not' do
+      let(:explicit_run_list) { [calling_recipe, first_wash_recipe] }
+      let(:wash_recipes) { [second_wash_recipe] }
+      it_should_behave_like 'a full sink'
+    end
+
+    # i.e. whose triggering recipes are still present in the run list
+    describe 'with dishes that were never dirty' do
+      let(:explicit_run_list) do
+        [calling_recipe, first_dish_recipe, second_dish_recipe]
+      end
+
+      it_should_behave_like 'an empty sink'
+    end
+
+    describe 'with a mix of dishes that were dirtied and not' do
+      let(:explicit_run_list) { [calling_recipe, first_dish_recipe] }
+      let(:wash_recipes) { [second_wash_recipe] }
+      it_should_behave_like 'a full sink'
+    end
+
+    describe 'with a mix of dishes that never dirty and already cleaned up' do
+      let(:explicit_run_list) do
+        [calling_recipe, first_dish_recipe, second_wash_recipe]
+      end
+
+      it_should_behave_like 'an empty sink'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+end

--- a/test/fixtures/cookbooks/test_dishes/metadata.rb
+++ b/test/fixtures/cookbooks/test_dishes/metadata.rb
@@ -1,0 +1,7 @@
+name              'test_dishes'
+maintainer        'Phil Smith'
+license           'MIT'
+description       'A test cookbook for dishes resources'
+version           '0.1.0'
+
+depends 'dishes'

--- a/test/fixtures/cookbooks/test_dishes/recipes/dish_spec_recipe.rb
+++ b/test/fixtures/cookbooks/test_dishes/recipes/dish_spec_recipe.rb
@@ -1,0 +1,8 @@
+attrs = node['test_dishes']['dish_spec_recipe']
+
+dishes_dish attrs['name'] do
+  action attrs['action'] if attrs.key?('action')
+  recipe attrs['recipe'] if attrs.key?('recipe')
+  wash_recipe attrs['wash_recipe'] if attrs.key?('wash_recipe')
+  sink attrs['sink'] if attrs.key?('sink')
+end

--- a/test/fixtures/cookbooks/test_dishes/recipes/first_wash_recipe.rb
+++ b/test/fixtures/cookbooks/test_dishes/recipes/first_wash_recipe.rb
@@ -1,0 +1,1 @@
+file '/tmp/first_wash_recipe_ran'

--- a/test/fixtures/cookbooks/test_dishes/recipes/integration_test_recipe.rb
+++ b/test/fixtures/cookbooks/test_dishes/recipes/integration_test_recipe.rb
@@ -1,0 +1,6 @@
+# The first dish is not dirty.
+include_recipe 'test_dishes::first_dish_recipe'
+
+# The second dish is dirty.
+
+dishes_sink 'default'

--- a/test/fixtures/cookbooks/test_dishes/recipes/second_wash_recipe.rb
+++ b/test/fixtures/cookbooks/test_dishes/recipes/second_wash_recipe.rb
@@ -1,0 +1,1 @@
+file '/tmp/second_wash_recipe_ran'

--- a/test/fixtures/cookbooks/test_dishes/recipes/sink_spec_recipe.rb
+++ b/test/fixtures/cookbooks/test_dishes/recipes/sink_spec_recipe.rb
@@ -1,0 +1,6 @@
+attrs = node['test_dishes']['sink_spec_recipe']
+
+dishes_sink attrs['name'] do
+  action attrs['action'] if attrs.key?('action')
+  sink attrs['sink'] if attrs.key?('sink')
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe file('/tmp/first_wash_recipe_ran') do
+  it { should_not exist }
+end
+
+describe file('/tmp/second_wash_recipe_ran') do
+  it { should exist }
+end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec


### PR DESCRIPTION
A `dish` is a triple kept in attribute state that contains:
- A `sink` label
- A "dish" `recipe`
- A `wash_recipe`.

It does not represent anything on the node itself: it is represented completely in chef server state.

A dish may be clean or dirty.  It is clean if either its `recipe` or `wash_recipe` are present in the node's recipe list, and dirty if neither are present.

Dishes support two actions.  The default, `:use`, ensures that the triple is present in the chef server's memory.  The `:toss` action ensures that it is absent instead.

A `sink` is a collection of dishes.  Dishes choose their sink with the `sink` attribute, with default `default`.  Sinks have a single action, `:wash`.  It considers each contained dish and, if it is dirty, `include_recipe`s the dish's `wash_recipe`.
